### PR TITLE
"Upcoming events" should only show events within the nearest future 7 days

### DIFF
--- a/src/backend/controller/posts.js
+++ b/src/backend/controller/posts.js
@@ -99,8 +99,7 @@ function listEvents(req, res) {
   var filter = {
     eventData: {$ne:null},
     accepted: 'APPROVED',
-    "eventData.from": { $gt: moment().startOf('day').toDate() },
-    "eventData.from": { $lt: moment().add(7, 'days').toDate() }
+    "eventData.from": { $gt: moment().startOf('day').toDate(), $lt: moment().add(7, 'days').toDate()},
   };
 
   return Promise.all([


### PR DESCRIPTION
mongoose solution. Previous code resulted in a union between dates later than today and dates earlier than a week from now. New solution results in an intersection. Issue: #57 
